### PR TITLE
fix: increase max topics limit and filter empty subscriptions

### DIFF
--- a/src/MQTTAnalyzer/views/host/form/HostFormModel.swift
+++ b/src/MQTTAnalyzer/views/host/form/HostFormModel.swift
@@ -71,7 +71,9 @@ func transform(subscriptions: [TopicSubscription]) -> [TopicSubscriptionFormMode
 }
 
 func transform(subscriptions: [TopicSubscriptionFormModel]) -> [TopicSubscription] {
-	return subscriptions.map { TopicSubscription(topic: $0.topic, qos: $0.qos)}
+	return subscriptions
+		.filter { !$0.topic.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+		.map { TopicSubscription(topic: $0.topic, qos: $0.qos)}
 }
 
 func validate(source host: HostFormModel) -> Bool {

--- a/src/MQTTAnalyzer/views/host/form/server/HostValidator.swift
+++ b/src/MQTTAnalyzer/views/host/form/server/HostValidator.swift
@@ -21,7 +21,7 @@ public class HostFormValidator {
 	}
 	
 	public class func validateMaxTopic(value: String) -> Int32? {
-		return validateInt(value: value, max: 2500)
+		return validateInt(value: value, max: 5000)
 	}
 	
 	public class func validateMaxMessagesOfSubFolders(value: String) -> Int32? {


### PR DESCRIPTION
Raise maximum topic count from 2500 to 5000 and exclude empty subscription topics when transforming form data.

fixes https://github.com/philipparndt/mqtt-analyzer/issues/144